### PR TITLE
Add README, LICENSE, and document command line arguments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,12 @@
+Copyright 2017 Fauna, Inc.
+
+Licensed under the Mozilla Public License, Version 2.0 (the "License"); you may
+not use this software except in compliance with the License. You may obtain a
+copy of the License at
+
+http://mozilla.org/MPL/2.0/
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,360 @@
-# faunadb-importer
+# FaunaDB Importer
 
-# TODO: document differences between windowns and linux config files
+FaunaDB Importer is a command line utility to help you import static data into
+[FaunaDB](https://fauna.com/product). It can import data into FaunaDB Cloud or
+an on-premises FaunaDB Enterprise cluster.
+
+Supported input file formats:
+- JSON
+- CSV
+- TSV
+
+Requirements:
+- Java 8+
+
+## Usage
+
+Download the [latest version](https://github.com/fauna/faunadb-importer/releases)
+and extract the zip file. Inside the extracted folder, run:
+
+```
+./bin/faunadb-importer \
+  import-file \
+  --secret <keys-secret> \
+  --class <class-name> \
+  <file-to-import>
+```
+
+__NOTE__: The command line arguments are the same on Windows, but you must use a
+different startup script. For example:
+
+```
+.\bin\faunadb-importer.bat import-file --secret <keys-secret> --class <class-name> <file-to-import>
+```
+
+For example:
+
+```
+./bin/faunadb-importer \
+  import-file \
+  --secret "abc" \
+  --class users \
+  data/users.json
+```
+
+The importer will load all data into the specified class, preserving the field
+names and types as described in the import file.
+
+You can also type `./bin/faunadb-importer --help` for more detailed information.
+
+## How it works
+
+The importer is a stateful process separated into two phases: ID generation
+and data import.
+
+First, the importer will parse all records and generate unique IDs by calling
+the [`next_id`](https://fauna.com/documentation/queries#misc_functions-code_next_id_code)
+function for each record. Pre-generating IDs beforehand allows us to import
+schemas containing relational data while keeping foreign keys consistent. It
+also ensures that we can safely re-run the process without the risk of
+duplicating information.
+
+In order to map legacy IDs to newly generated Fauna IDs, the importer will:
+- Check if there is a field configured with the `ref` type. The field's value
+  will be used as the lookup term for the new Fauna ID.
+- If no field is configured with the`ref` type, the importer will assign a
+  sequential number for each record as the lookup term for the new Fauna ID.
+
+Once this phase completes, the pre-generated IDs will be stored at the `cache`
+directory. In case of a re-run, the importer will load the IDs from disk and
+skip this phase.
+
+Second, the importer will insert all records into FaunaDB, using the
+pre-generated IDs from the first step as their [ref](https://fauna.com/documentation/queries#values-special_types)
+field.
+
+At this phase, if the import fails to run due to data inconsistency, it is:
+- __SAFE__ to fix data inconsistencies in any field **except** fields configured
+  with the `ref` type.
+- __NOT SAFE__ to change fields configured with the `ref` type as they will be
+  used as the lookup term for the pre-generated ID from the first phase.
+- __NOT SAFE__ to remove entries from the import file if you __don't have__ a
+  field configured as a `ref` field; this will alter the sequential number
+  assigned to the record.
+
+
+As long as you keep the `cache` directory intact, it is safe to re-run the
+process until the import completes. If you want to use the importer again with a
+different input file, you __must__ empty the `cache` directory first.
+
+### File structure
+
+```
+.
+├── README.md                    # This file
+├── bin                          #
+│   ├── faunadb-importer         # Unix startup script
+│   └── faunadb-importer.bat     # Windows startup script
+├── cache                        # Where the importer saves its cache
+├── data                         # Where you should copy the files you wish to import
+├── lib                          #
+│   └── faunadb-importer-1.0.jar # The importer library
+└── logs                         # Logs for each execution
+```
+
+## Advanced usage
+
+### Configuring fields
+
+When importing `JSON` files, field names and types are optional; when
+importing text files, you must specify each field's name and type in order using
+the `--format` option:
+
+```
+./bin/faunadb-importer \
+  import-file \
+  --secret "<your-keys-secret-here>" \
+  --class <your-class-name> \
+  --format "<field-name>:<field-type>,..."
+  <file-to-import>
+```
+
+For example:
+
+```
+./bin/faunadb-importer \
+  import-file \
+  --secret "abc" \
+  --class users \
+  --format "id:ref, username:string, vip:bool" \
+  data/users.csv
+```
+
+#### Supported types:
+
+|Name     | Description                      |
+|---------|----------------------------------|
+|`string` | A string value                   |
+|`long`   | A numeric value                  |
+|`double` | A double precision numeric value |
+|`bool`   | A boolean value                  |
+|`ref`    | A [ref](https://fauna.com/documentation/queries#values-special_types) value. It can be used to mark the field as a primary key or to reference another class when [importing multiple files](#importing-multiple-files). For example `city:ref(cities)`|
+|`ts`     | A numeric value representing the number of milliseconds passed since 1970-01-01 00:00:00. You can also specify your own [format](http://www.joda.org/joda-time/key_format.html) as a parameter. For example: `ts("dd/MM/yyyyTHH:mm:ss.000Z")`|
+|`date`   | A date value formatted as `yyyy-MM-dd`. You can also specify your own [format](http://www.joda.org/joda-time/key_format.html) as a parameter. For example: `date("dd/MM/yyyy")`|
+
+### Renaming fields
+
+You can rename fields from the input file as they are inserted into FaunaDB with
+the following syntax:
+
+```
+<field-name>-><new-field-name>:<field-type>
+```
+
+For example:
+
+```
+./bin/faunadb-importer \
+  import-file \
+  --secret "abc" \
+  --class users \
+  --format "id:ref, username->userName:string, vip->VIP:bool" \
+  data/users.csv
+```
+
+### Ignoring root element
+
+When importing a `JSON` file where the root element of the file is an `array`, or
+when importing a text file where the first line is the file header, you can skip
+the root element with the `--skip-root` option. For example:
+
+```
+./bin/faunadb-importer \
+  import-file \
+  --secret "abc" \
+  --class users \
+  --skip-root true
+  data/users.csv
+```
+
+### Ignoring fields
+
+You can ignore fields with the `--ignore-fields` option. For example:
+
+```
+./bin/faunadb-importer \
+  import-file \
+  --secret "abc" \
+  --class users \
+  --format "id:ref, username->userName:string, vip->VIP:bool" \
+  --ignore-fields "id"
+  data/users.csv
+```
+
+_NOTE_: In the above example, we omit the `id` field when importing the data into FaunaDB, but we still use the `id` field as the `ref` type so that the importer tool will properly map the newly-generated Fauna ID for that specific user.
+
+### How to maintain data in chronological order
+
+You can maintain chronological order when importing data by using the
+`--ts-field` option. For example:
+
+```
+./bin/faunadb-importer \
+  import-file \
+  --secret "abc" \
+  --class users \
+  --ts-field "created_at"
+  data/users.csv
+```
+
+The value configured in the `--ts-field` option will be used as the `ts`
+field for the imported instance.
+
+### Importing to your own cluster
+
+By default, the importer will load your data into FaunaDB Cloud. If you wish to
+import the data to your own cluster, you can use the `--endpoints` option. For
+example:
+
+```
+./bin/faunadb-importer \
+  import-file \
+  --secret "abc" \
+  --class users \
+  --endpoints "http://10.0.0.120:8443, http://10.0.0.121:8443"
+  data/users.csv
+```
+
+_NOTE_: The importer will load balance requests across all configured endpoints.
+
+### Importing multiple files
+
+In order to import multiple files, you must run the importer with a schema
+definition file. For example:
+
+```
+./bin/faunadb-importer \
+  import-schema \
+  --secret "abc" \
+  data/my-schema.yaml
+```
+
+#### Schema definition syntax
+
+```yaml
+<file-address>:
+  class: <class-name>
+  skipRoot: <boolean>
+  tsField: <field-name>
+  fields:
+    - name: <field-name>
+      type: <field-type>
+      rename: <new-field-name>
+  ignoredFields:
+    - <field-name>
+```
+
+For example:
+
+```yaml
+data/users.json:
+  class: users
+  fields:
+    - name: id
+      type: ref
+
+    - name: name
+      type: string
+
+  ignoredFields:
+    - id
+
+data/tweets.csv:
+  class: tweets
+  tsField: created_at
+  fields:
+    - name: id
+      type: ref
+
+    - name: user_id
+      type: ref(users)
+      rename: user_ref
+
+    - name: text
+      type: string
+      rename: tweet
+
+  ignoredFields:
+    - id
+    - created_at
+```
+
+## Performance considerations
+
+The importer's default settings should be enough to provide good performance for
+most cases. Still, there are a few things that are worth mentioning:
+
+### Memory
+
+You can set the maximum amount of memory available to the import tool with
+`-J-Xmx`. For example:
+
+```
+./bin/faunadb-importer \
+  -J-Xmx10G \
+  import-schema \
+  --secret "abc" \
+  data/my-schema.yaml
+```
+
+_NOTE_: Parameters prefixed with `-J` must be placed as the first parameters for
+the import tool.
+
+### Batch sizes
+
+The size of each individual batch is controlled by `--batch-size` parameter.
+
+In general, individual requests will have a higher latency with a larger batch
+size. However, the overall throughput of the import process may increase by
+inserting more records in a single request.
+
+Large batches can exceed the maximum size of a HTTP request, forcing the import
+tool to split the batch into smaller requests, therefore degrading the overall
+performance.
+
+Default: 50 records per batch.
+
+### Managing concurrency
+
+Concurrency is configured using the `--max-requests-per-endpoint` parameter.
+
+In practice, the number of concurrent requests is the number of
+`max-requests-per-endpoint` multiplied by the number of endpoints configured by
+the `endpoints` parameter.
+
+A large number of concurrent requests can cause timeouts. When timeouts happen,
+the import tool will retry failing requests applying exponential backoff to each
+request.
+
+Default: 4 concurrent requests per endpoint.
+
+### Backoff configuration
+
+Exponential backoff is a combination of the follow parameters:
+- `network-errors-backoff-time`: The number of seconds to delay new requests
+  when the network is unstable. Default: 1 second.
+- `network-errors-backoff-factor`: The number to multiply
+  `network-errors-backoff-time` by per network issue detected; not to exceed
+  `max-network-errors-backoff-time`. Default: 2.
+- `max-network-errors-backoff-time`: The maximum number of seconds to delay new
+  requests when applying exponential backoff. Default: 60 seconds.
+- `max-network-errors`: The maximum number of network errors tolerated within
+  the configured timeframe. Default: 50 errors.
+- `reset-network-errors-period`: The number of seconds the import tool will wait
+  for a new network error before resetting the error count. Default: 120
+  seconds.
+
+## License
+
+All projects in this repository are licensed under the
+[Mozilla Public License](./LICENSE)

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,6 @@ lazy val root = (project in file("."))
     ),
     fork := true,
 
-    // TODO: Check licences
     libraryDependencies ++= Seq(
       // Main
       "com.faunadb" %% "faunadb-scala" % "1.2.0",

--- a/src/main/scala/faunadb/importer/CmdArgs.scala
+++ b/src/main/scala/faunadb/importer/CmdArgs.scala
@@ -14,7 +14,7 @@ import java.net.URL
 import java.util
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import scala.util.Try
+import scala.util._
 import scopt._
 
 private[importer] object CmdArgs {
@@ -31,22 +31,24 @@ private[importer] object CmdArgs {
     import ContextBuilder.Dsl._
 
     head(
-      """faunadb-import 1.0-SNAPSHOT
+      """faunadb-import
         |For more information check https://github.com/fauna/faunadb-importer
         |""".stripMargin
     )
 
     opt[String]("secret")
-      .text("FaunaDB key's secret to use when authenticating requests")
-      .abbr("s")
+      .text("The FaunaDB key's secret to use")
       .required()
       .validate(notBlank("secret"))
       .foreach(c.config += Secret(_))
 
     opt[Seq[String]]("endpoints")
-      .text("FaunaDB endpoints's urls. The import load will be balanced across all endpoints")
+      .text(
+        "The FaunaDB endpoints urls. " +
+          "The import will load balance requests across all endpoints. " +
+          "Defaults to FaunaDB Cloud."
+      )
       .valueName("<url,url...>")
-      .abbr("e")
       .validate { endpoints =>
         endpoints
           .find(url => !isValidUrl(url))
@@ -56,61 +58,52 @@ private[importer] object CmdArgs {
       .foreach(c.config += Endpoints(_))
 
     opt[Int]("batch-size")
-      .text("Number of queries to be grouped at a single batch")
-      .abbr("bs")
+      .text("Number of records to be grouped in a single batch. Default: 50.")
       .validate(biggerThanZero("Batch size"))
       .foreach(c.config += BatchSize(_))
 
     opt[Int]("max-requests-per-endpoint")
-      .text("The maximum number of concurrent requests per endpoint")
-      .abbr("me")
+      .text("The maximum number of concurrent requests per endpoint. Default: 4.")
       .validate(biggerThanZero("Max requests per endpoint"))
       .foreach(c.config += MaxRequestsPerEndpoint(_))
 
     opt[Int]("max-network-errors")
-      .text(
-        "The maximum number of network erros tolerated " +
-          "within the configured period of time")
-      .abbr("ne")
+      .text("The maximum number of network errors tolerated within the configured timeframe: Default: 50.")
       .validate(biggerThanZero("Max network errors"))
       .foreach(c.config += MaxNetworkErrors(_))
 
     opt[Int]("reset-network-errors-period")
       .text(
-        "The number of seconds in which the network errors " +
-          "count will be reset if no new errors were found")
-      .abbr("re")
+        "The number of seconds the import tool will wait for a new network error before resetting the error count. " +
+          "Default: 120.")
       .validate(biggerThanZero("Reset network errors period"))
       .foreach(n => c.config += NetworkErrorsResetTime(n.seconds))
 
     opt[Int]("network-errors-backoff-time")
-      .text(
-        "The number of seconds to delay new requests when " +
-          "the network is unstable")
-      .abbr("bt")
+      .text("The number of seconds to delay new requests when the network is unstable. Default: 1.")
       .validate(biggerThanZero("Network errors backoff time"))
       .foreach(n => c.config += NetworkErrorsBackoffTime(n.seconds))
 
-    opt[Int]("max-network-errors-backoff-time")
-      .text(
-        "The maximum number of seconds to delay new requests " +
-          "when applying explonential backoff")
-      .abbr("mb")
-      .validate(biggerThanZero("Max network errors backoff time"))
-      .foreach(n => c.config += MaxNetworkErrorsBackoffTime(n.seconds))
-
     opt[Int]("network-errors-backoff-factor")
       .text(
-        "The factor used when exponentially backing off requests due " +
-          "to network instability")
-      .abbr("bf")
+        "The number to multiply network-errors-backoff-time by per network issue detected; " +
+          "not to exceed max-network-errors-backoff-time. Default: 2.")
       .validate(biggerThanZero("Network errors backoff factor"))
       .foreach(c.config += NetworkErrorsBackoffFactor(_))
 
+    opt[Int]("max-network-errors-backoff-time")
+      .text("The maximum number of seconds to delay new requests when applying exponential backoff. Default: 60.")
+      .validate(biggerThanZero("Max network errors backoff time"))
+      .foreach(n => c.config += MaxNetworkErrorsBackoffTime(n.seconds))
+
     opt[String]("error-strategy")
-      .text("The error strategy to be used")
+      .text(
+        """The error strategy to be used. Default: stop.
+          |          stop     Log and stop the import as soon as any error happens.
+          |          continue Log the error but continue the import process.
+        """.stripMargin
+      )
       .valueName(s"<stop|continue>")
-      .abbr("r")
       .validate(either("Error strategy", "stop", "continue"))
       .foreach {
         case "stop"     => c.config += OnError(ErrorStrategy.StopOnError)
@@ -118,9 +111,14 @@ private[importer] object CmdArgs {
       }
 
     opt[String]("report-type")
-      .text("Progress report strategy to use")
+      .text(
+        """Progress report strategy to be used. Default: inline.
+          |          inline  Report metrics in the same line. No console scroll.
+          |          detaild Report detailed metrics every 20 seconds. Multiple log lines.
+          |          silent  Do not report metrics.
+        """.stripMargin
+      )
       .valueName(s"<inline|detailed|silent>")
-      .abbr("t")
       .validate(either("Report type", "inline", "detailed", "silent"))
       .foreach {
         case "inline"   => c.config += Report(ReportType.Inline)
@@ -138,10 +136,7 @@ private[importer] object CmdArgs {
         .foreach(c.context.file),
 
       opt[Seq[String]]("format")
-        .text(
-          "Fields' definition in the following format: " +
-            "<field-name>[->new-name]:<field-type>[(config)],...")
-        .abbr("f")
+        .text("Fields definition in the following format: <field-name>[->new-name]:<field-type>[(config)],...")
         .validate {
           _.foldLeft(success) { case (prev, field) =>
             prev.right flatMap { _ =>
@@ -166,22 +161,19 @@ private[importer] object CmdArgs {
 
       opt[String]("class")
         .text("The class in which the data will be imported")
-        .abbr("c")
         .required()
         .validate(notBlank("class"))
         .foreach(c.context += Clazz(_)),
 
       opt[Boolean]("skip-root")
-        .abbr("k")
         .text(
           "Configures the parser to ignore the first line for TSV/CSV " +
-            "files or to ignore first array element in JSON files"
+            "files or to ignore first array element in JSON files. Default: false."
         )
         .foreach(c.context += SkipRoot(_)),
 
       opt[Seq[String]]("ignore-fields")
         .text("Fields to be ignored when inserting data into FaunaDB")
-        .abbr("i")
         .validate { fields =>
           if (fields.forall(_.trim.nonEmpty)) success
           else failure("ignore-fields can't have a blank field")
@@ -189,8 +181,7 @@ private[importer] object CmdArgs {
         .foreach(_.foreach(c.context += Ignore(_))),
 
       opt[String]("ts-field")
-        .text("Field to be used as a timestamp for each inserted instance at FaunaDB")
-        .abbr("t")
+        .text("Field to be used as a timestamp for each inserted instance in FaunaDB")
         .validate(notBlank("ts-field"))
         .foreach(c.context += TSField(_))
     )

--- a/src/main/scala/faunadb/importer/process/phases/GenerateIds.scala
+++ b/src/main/scala/faunadb/importer/process/phases/GenerateIds.scala
@@ -20,7 +20,7 @@ private[process] final class GenerateIds(cacheWrite: IdCache.Write, connPool: Co
   protected def buildQuery(record: Record): Result[Expr] = NextIdQuery
 
   protected def handleResponse(record: Record, value: FValue): Result[Unit] = {
-    faunaIdAsString(value) flatMap { newId =>
+    faunaIdAsLong(value) flatMap { newId =>
       cacheWrite
         .put(c.clazz, record.id, newId)
         .map(_ => Err(s"Duplicated ID ${record.id} found for recored at: ${record.localized}"))
@@ -28,7 +28,7 @@ private[process] final class GenerateIds(cacheWrite: IdCache.Write, connPool: Co
     }
   }
 
-  private def faunaIdAsString(id: FValue): Result[Long] = {
+  private def faunaIdAsLong(id: FValue): Result[Long] = {
     id.to[String].map(toLong) getOrElse Err(s"Fauna did NOT returned a string ID. Value returned: $id")
   }
 


### PR DESCRIPTION
It would be nice to review the output of `--help` as well:

```
faunadb-import
For more information check https://github.com/fauna/faunadb-importer

Usage: faunadb-import [import-file|import-schema] [options] <args>...

  --secret <value>
        The FaunaDB key's secret to use
  --endpoints <url,url...>
        The FaunaDB endpoints' urls. The import will load balance requests across all endpoints. Defaults to FaunaDB Cloud.
  --batch-size <value>
        Number of records to be grouped at a single batch. Default: 50.
  --max-requests-per-endpoint <value>
        The maximum number of concurrent requests per endpoint. Default: 4.
  --max-network-errors <value>
        The maximum number of network erros tolerated within the configured time frame: Default: 50.
  --reset-network-errors-period <value>
        The number of seconds in which the network errors count will be reset if no new errors were found. Default: 120.
  --network-errors-backoff-time <value>
        The number of seconds to delay new requests when the network is unstable. Default: 1.
  --network-errors-backoff-factor <value>
        The factor used when exponentially backoff requests when the network is unstable. Default: 2.
  --max-network-errors-backoff-time <value>
        The maximum number of seconds to delay new requests when applying explonential backoff. Default: 60.
  --error-strategy <stop|continue>
        The error strategy to be used. Default: stop.
          stop     Log and stop the import as soon as any error happens.
          continue Log the error but continues the import process.
        
  --report-type <inline|detailed|silent>
        Progress report strategy to be used. Default: inline.
          inline  Report metrics in the same line. No console scrool.
          detaild Report detailed metrics every 20 seconds. Multiple log lines.
          silent  Do not report metrics.
        
  --help
        Display this text
Command: import-file [options] file

  file
        File to import. Supported formats: JSON, CSV, and TSV
  --format <value>
        Fields' definition in the following format: <field-name>[->new-name]:<field-type>[(config)],...
  --class <value>
        The class in which the data will be imported
  --skip-root <value>
        Configures the parser to ignore the first line for TSV/CSV files or to ignore first array element in JSON files. Default: false.
  --ignore-fields <value>
        Fields to be ignored when inserting data into FaunaDB
  --ts-field <value>
        Field to be used as a timestamp for each inserted instance at FaunaDB
Command: import-schema schema-file

  schema-file
        YAML schema definition
```