### PR TITLE
Optimize for IO bounded parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+2.0.0-SNAPSHOT
+* Improvements for I/O bounded parallelism
+
 1.0.0
 * First official release

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,7 @@ lazy val root = (project in file("."))
     javaOptions ++= Seq(
       "-server",
       "-XX:+UseCompressedOops",
-      "-XX:+UseStringDeduplication",
-      "-Dmonix.environment.batchSize=128"
+      "-XX:+UseStringDeduplication"
     ),
     fork := true,
 

--- a/src/main/scala/faunadb/importer/CmdArgs.scala
+++ b/src/main/scala/faunadb/importer/CmdArgs.scala
@@ -62,10 +62,12 @@ private[importer] object CmdArgs {
       .validate(biggerThanZero("Batch size"))
       .foreach(c.config += BatchSize(_))
 
-    opt[Int]("max-requests-per-endpoint")
-      .text("The maximum number of concurrent requests per endpoint. Default: 4.")
-      .validate(biggerThanZero("Max requests per endpoint"))
-      .foreach(c.config += MaxRequestsPerEndpoint(_))
+    opt[Int]("concurrent-streams")
+      .text(
+        "Number of concurrent streams used to send requests to the cluster. " +
+          "Default: the number of available processors * 2")
+      .validate(biggerThanZero("Concurrent streams"))
+      .foreach(c.config += ConcurrentStreams(_))
 
     opt[Int]("max-network-errors")
       .text("The maximum number of network errors tolerated within the configured timeframe: Default: 50.")

--- a/src/main/scala/faunadb/importer/config/Config.scala
+++ b/src/main/scala/faunadb/importer/config/Config.scala
@@ -16,8 +16,8 @@ case class Config(
   // Number of queries to be executed at a single batch
   batchSize: Int = 50,
 
-  // Maximum number of concurrent requests per endpoint
-  maxRequestsPerEndpoint: Int = 4,
+  // Number of parallel streams used to send request to the server
+  concurrentStreams: Int = Runtime.getRuntime.availableProcessors() * 2,
 
   // Maximum number of network errors tolerated
   maxNetworkErrors: Int = 50,
@@ -69,9 +69,9 @@ object ConfigBuilder {
     def Secret(value: String): BuildStep = _.copy(secret = value)
     def Endpoints(value: Seq[String]): BuildStep = _.copy(endpoints = value)
     def BatchSize(value: Int): BuildStep = _.copy(batchSize = value)
+    def ConcurrentStreams(value: Int): BuildStep = _.copy(concurrentStreams = value)
     def OnError(value: ErrorStrategy): BuildStep = _.copy(errorStrategy = value)
     def Report(value: ReportType): BuildStep = _.copy(reportType = value)
-    def MaxRequestsPerEndpoint(value: Int): BuildStep = _.copy(maxRequestsPerEndpoint = value)
     def MaxNetworkErrors(value: Int): BuildStep = _.copy(maxNetworkErrors = value)
     def NetworkErrorsResetTime(value: FiniteDuration): BuildStep = _.copy(networkErrorsResetTime = value)
     def NetworkErrorsBackoffTime(value: FiniteDuration): BuildStep = _.copy(networkErrorsBackoffTime = value)

--- a/src/main/scala/faunadb/importer/persistence/ConnectionPool.scala
+++ b/src/main/scala/faunadb/importer/persistence/ConnectionPool.scala
@@ -5,94 +5,42 @@ import com.ning.http.client._
 import faunadb._
 import faunadb.importer.report._
 import java.util.concurrent.TimeUnit._
-import java.util.concurrent.atomic._
-import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
 trait ConnectionPool {
-  def borrowClient(): FaunaClient
-  def returnClient(client: FaunaClient): Unit
-  def maxConcurrentReferences: Int
+  def pickClient(): FaunaClient
   def close(): Unit
 }
 
 object ConnectionPool {
-  def apply(endpoints: Seq[String], secret: String, maxRefCountPerEndpoint: Int): ConnectionPool =
-    new FaunaClientPool(endpoints, secret, maxRefCountPerEndpoint)
+  def apply(endpoints: Seq[String], secret: String): ConnectionPool = {
+    val httpWrapper = new HttpWrapper // Reuse http client
+
+    endpoints match {
+      case endpoint :: Nil => new SingleConnPool(FaunaClient(secret, endpoint, httpClient = httpWrapper))
+      case Nil             => new SingleConnPool(FaunaClient(secret, httpClient = httpWrapper))
+      case _               => new MultipleConnPool(endpoints map (FaunaClient(secret, _, httpClient = httpWrapper)))
+    }
+  }
 }
 
-private final class FaunaClientPool(endpoints: Seq[String], secret: String, maxRefCountPerEndpoint: Int)
-  extends ConnectionPool {
+private final class SingleConnPool(client: FaunaClient) extends ConnectionPool {
+  def pickClient(): FaunaClient = client
+  def close(): Unit = client.close()
+}
 
-  private val refCountByClient: Map[FaunaClient, AtomicInteger] = {
-    def newClient(endpoint: String = null): FaunaClient =
-      FaunaClient(secret, endpoint, httpClient = new HttpWrapper())
-
-    val clients =
-      if (endpoints.isEmpty) Seq(newClient())
-      else endpoints.map(newClient)
-
-    clients
-      .map(_ -> new AtomicInteger(0))
-      .toMap
-  }
-
-  private val clientsByIndex = refCountByClient.toIndexedSeq
-  private val poolSize = refCountByClient.size
-
-  val maxConcurrentReferences: Int = maxRefCountPerEndpoint * poolSize
-
+private final class MultipleConnPool(clients: Seq[FaunaClient]) extends ConnectionPool {
   @volatile
-  private var searchIndex = -1
+  private[this] var searchIndex = -1
+  private[this] val clientsByIndex = clients.toIndexedSeq
+  private[this] val poolSize = clients.size
 
-  @tailrec
-  def borrowClient(): FaunaClient = {
-    var pickedClient: FaunaClient = null
-    var pickedRefCount: AtomicInteger = null
-    var minRefCountFound = Int.MaxValue
-
-    // Start from a different position everytime so we don't
-    // prefer the first few clients in the pool
+  def pickClient(): FaunaClient = {
     searchIndex = Math.max((searchIndex + 1) % poolSize, 0)
-    val startIndex = searchIndex
-    var walked = 0
-
-    while (walked < poolSize) {
-      val (client, refCount) = clientsByIndex(Math.max((startIndex + walked) % poolSize, 0))
-      val currentCount = refCount.get()
-
-      // Prefer the client with less references to it
-      if (currentCount < minRefCountFound && currentCount < maxRefCountPerEndpoint) {
-        minRefCountFound = currentCount
-        pickedRefCount = refCount
-        pickedClient = client
-      }
-
-      walked += 1
-    }
-
-    if (pickedClient == null) {
-      throw new IllegalStateException(
-        "Maximum number of concurrent references was reached. " +
-          "Callers to bottowClient must respect the value of maxConcurrentReferences"
-      )
-    }
-
-    if (!pickedRefCount.compareAndSet(minRefCountFound, minRefCountFound + 1)) {
-      // Another thread got the client first. Retry!
-      borrowClient()
-    } else {
-      pickedClient
-    }
+    clientsByIndex(searchIndex)
   }
 
-  def returnClient(client: FaunaClient): Unit = {
-    refCountByClient.get(client) foreach (_.decrementAndGet())
-  }
-
-  def close(): Unit = {
-    refCountByClient.keys foreach (_.close())
-  }
+  def close(): Unit = clients foreach (_.close())
 }
 
 private final class HttpWrapper extends AsyncHttpClient(

--- a/src/main/scala/faunadb/importer/persistence/ConnectionPool.scala
+++ b/src/main/scala/faunadb/importer/persistence/ConnectionPool.scala
@@ -31,13 +31,14 @@ private final class SingleConnPool(client: FaunaClient) extends ConnectionPool {
 
 private final class MultipleConnPool(clients: Seq[FaunaClient]) extends ConnectionPool {
   @volatile
-  private[this] var searchIndex = -1
+  private[this] var searchIndex = 0
   private[this] val clientsByIndex = clients.toIndexedSeq
   private[this] val poolSize = clients.size
 
   def pickClient(): FaunaClient = {
-    searchIndex = Math.max((searchIndex + 1) % poolSize, 0)
-    clientsByIndex(searchIndex)
+    val client = clientsByIndex(searchIndex)
+    searchIndex = (searchIndex + 1) % poolSize
+    client
   }
 
   def close(): Unit = clients foreach (_.close())

--- a/src/main/scala/faunadb/importer/process/Import.scala
+++ b/src/main/scala/faunadb/importer/process/Import.scala
@@ -14,7 +14,7 @@ object Import {
   val CacheFile = new File("cache/ids")
 
   def run(config: Config, filesToImport: Seq[(File, Context)]) {
-    val pool = ConnectionPool(config.endpoints, config.secret, config.maxRequestsPerEndpoint)
+    val pool = ConnectionPool(config.endpoints, config.secret)
 
     try {
       for (step <- steps(pool, filesToImport)) {

--- a/src/test/scala/faunadb/importer/CmdArgsSpec.scala
+++ b/src/test/scala/faunadb/importer/CmdArgsSpec.scala
@@ -12,7 +12,7 @@ class CmdArgsSpec extends SimpleSpec {
         "--secret", "abc",
         "--endpoints", "http://localhost:8443, http://localhost:8444",
         "--batch-size", "2",
-        "--max-requests-per-endpoint", "5",
+        "--concurrent-streams", "10",
         "--error-strategy", "continue",
         "--format", "id:ref, name:string, age:long, oldName->newName:string",
         "--skip-root", "true",

--- a/src/test/scala/faunadb/importer/config/ConfigBuilderSpec.scala
+++ b/src/test/scala/faunadb/importer/config/ConfigBuilderSpec.scala
@@ -12,7 +12,7 @@ class ConfigBuilderSpec extends SimpleSpec {
     builder += Secret("abc")
     builder += Endpoints(Seq("url1", "url2"))
     builder += BatchSize(2)
-    builder += MaxRequestsPerEndpoint(3)
+    builder += ConcurrentStreams(2)
     builder += OnError(ErrorStrategy.DoNotStop)
 
     builder.result() shouldBe Ok(
@@ -20,7 +20,7 @@ class ConfigBuilderSpec extends SimpleSpec {
         secret = "abc",
         endpoints = Seq("url1", "url2"),
         batchSize = 2,
-        maxRequestsPerEndpoint = 3,
+        concurrentStreams = 2,
         errorStrategy = ErrorStrategy.DoNotStop
       )
     )

--- a/src/test/scala/faunadb/importer/config/ContextBuilderSpec.scala
+++ b/src/test/scala/faunadb/importer/config/ContextBuilderSpec.scala
@@ -15,7 +15,6 @@ class ContextBuilderSpec extends SimpleSpec {
     secret = "abc",
     endpoints = Seq("url1", "url2"),
     batchSize = 2,
-    maxRequestsPerEndpoint = 3,
     errorStrategy = ErrorStrategy.DoNotStop
   )
 

--- a/src/test/scala/faunadb/importer/persistence/ConnectionPoolSpec.scala
+++ b/src/test/scala/faunadb/importer/persistence/ConnectionPoolSpec.scala
@@ -4,51 +4,38 @@ import faunadb.specs._
 
 class ConnectionPoolSpec extends SimpleSpec {
 
-  "The connection pool" should "return the maximun number of concurrent requests allowed" in {
+  "The connection pool" should "balance across all endpoints" in {
     val pool = ConnectionPool(
-      endpoints = Seq(
-        "http://localhost:8443",
-        "http://localhost:8444",
-        "http://localhost:8445"
-      ),
       secret = "secret",
-      maxRefCountPerEndpoint = 5
-    )
-
-    try pool.maxConcurrentReferences shouldBe 15 finally pool.close()
-  }
-
-  it should "point to cloud if no endpoint" in {
-    val pool = ConnectionPool(Seq.empty, "secret", 1)
-    try pool.maxConcurrentReferences shouldBe 1 finally pool.close() // Has a single client pointing to cloud
-  }
-
-  it should "balance across all endpoints" in {
-    val pool = ConnectionPool(
       endpoints = Seq(
         "http://localhost:8443",
         "http://localhost:8444"
       ),
-      secret = "secret",
-      maxRefCountPerEndpoint = 3
     )
 
     try {
-      val cA = pool.borrowClient()
-      val cB = pool.borrowClient()
-      val cA1 = pool.borrowClient()
+      val cA1 = pool.pickClient()
+      val cB1 = pool.pickClient()
+      val cA2 = pool.pickClient()
 
-      cA shouldNot be(cB) // Choose different clients when all ref counts are the same
-      cA1 shouldBe cA // Go around and start again when all ref counts are the same
-
-      pool.returnClient(cB)
-      pool.borrowClient() shouldBe cB // Pick the one with less references
-      pool.borrowClient() shouldBe cB // Pick the one with less references
-      pool.borrowClient() shouldBe cB // Pick anyone since all ref counts are the same
-      pool.borrowClient() shouldBe cA // Go around and start again when all ref counts are the same
+      cA1 shouldNot be(cB1) // Choose different clients when all ref counts are the same
+      cA1 shouldBe cA2 // Go around and start again when all ref counts are the same
     } finally {
       pool.close()
     }
   }
 
+  it should "point to cloud if no endpoint" in {
+    val pool = ConnectionPool(
+      secret = "secret",
+      endpoints = Seq.empty,
+    )
+
+    try {
+      val client = pool.pickClient()
+      client shouldNot be(null) // Default to cloud
+    } finally {
+      pool.close()
+    }
+  }
 }

--- a/src/test/scala/faunadb/specs/Mocks.scala
+++ b/src/test/scala/faunadb/specs/Mocks.scala
@@ -14,8 +14,7 @@ trait Mocks {
 
     val connPool: ConnectionPool = {
       val pool = stub[ConnectionPool]
-      (pool.borrowClient _).when().returns(faunaClient)
-      (pool.maxConcurrentReferences _).when().returns(1)
+      (pool.pickClient _).when().returns(faunaClient)
       pool
     }
 


### PR DESCRIPTION
- Reshape the Monix stream for better back-pressure support;
- Use a IO scheduler (backed by a cached thread pool);
- Differentiate happy from error path while processing streams to avoid extra sequence transformations.